### PR TITLE
Fixed back button for instructors

### DIFF
--- a/client/src/components/common/NavBar.js
+++ b/client/src/components/common/NavBar.js
@@ -43,7 +43,7 @@ class NavBar extends React.Component {
       this.props.changeMode(AppMode.DELIVERABLES);
     }
     else if (this.props.mode === AppMode.COURSE_INFO) {
-      if(this.props.accountType === "Instructor"){
+      if(this.props.userType === "Instructor"){
 
         this.props.changeMode(AppMode.INSTRUCTOR_DASHBOARD);
 


### PR DESCRIPTION
Overview
Fixes a bug with the back button.

Details
When an instructor opened up the course info page for a course and tried to hit a back button, it went to the admin dashboard. I changed this so it redirects to the course table, as intended.

![image](https://user-images.githubusercontent.com/37024281/101969664-837f4f00-3bda-11eb-8d42-2ffc7cffbfcf.png)
